### PR TITLE
Make typescript a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "type": "git",
     "url": "https://github.com/nucleic/kiwi.git"
   },
-  "devDependencies": {
+  "dependencies": {
     "typescript": "^2.3.0"
   },
-  "dependencies": {},
+  "devDependencies": {},
   "scripts": {
     "build": "./node_modules/.bin/tsc"
   },


### PR DESCRIPTION
Trying to install bokehjs 0.12.5 from npm the install fails at this repo. It fails because "build": "./node_modules/.bin/tsc" can't be found. I imagine that making typescript a dependency might fix this issue.